### PR TITLE
Add bitcoin forecast script

### DIFF
--- a/bitcoin/README.md
+++ b/bitcoin/README.md
@@ -1,0 +1,35 @@
+# Bitcoin Price Forecasting
+
+This directory contains a simple script to forecast future Bitcoin closing prices using an ARIMA time series model. Historical price data is downloaded from Yahoo Finance with [`yfinance`](https://pypi.org/project/yfinance/).
+
+## Requirements
+
+The script depends on:
+
+- `pandas`
+- `numpy`
+- `yfinance`
+- `statsmodels`
+- `matplotlib` (optional for plotting)
+
+Install these packages with pip:
+
+```bash
+pip install pandas numpy yfinance statsmodels matplotlib
+```
+
+## Usage
+
+Run the script from the repository root:
+
+```bash
+python bitcoin/bitcoin_forecast.py --start 2020-01-01 --steps 30 --plot
+```
+
+Arguments:
+
+- `--start`: Start date (YYYY-MM-DD) for downloading historical data. Defaults to `2020-01-01`.
+- `--steps`: Number of days to forecast ahead. Defaults to `30`.
+- `--plot`: Display a plot of historical and forecast data.
+
+The forecasted prices are printed to stdout and optionally plotted.

--- a/bitcoin/bitcoin_forecast.py
+++ b/bitcoin/bitcoin_forecast.py
@@ -1,0 +1,55 @@
+import argparse
+import pandas as pd
+import yfinance as yf
+import matplotlib.pyplot as plt
+from statsmodels.tsa.arima.model import ARIMA
+
+
+def download_close_prices(start_date: str = "2020-01-01") -> pd.Series:
+    """Download daily closing prices for Bitcoin from Yahoo Finance."""
+    data = yf.download("BTC-USD", start=start_date)
+    if "Close" not in data:
+        raise ValueError("Unexpected data format: 'Close' column missing")
+    return data["Close"]
+
+
+def forecast_prices(series: pd.Series, steps: int = 30) -> pd.Series:
+    """Fit an ARIMA model and forecast future prices."""
+    model = ARIMA(series, order=(5, 1, 0))
+    fitted = model.fit()
+    forecast = fitted.forecast(steps=steps)
+    # Align forecast index to continue from series end
+    forecast.index = pd.date_range(series.index[-1] + pd.Timedelta(days=1),
+                                   periods=steps, freq="D")
+    return forecast
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Forecast Bitcoin closing prices using an ARIMA model"
+    )
+    parser.add_argument("--start", default="2020-01-01",
+                        help="Historical data start date (YYYY-MM-DD)")
+    parser.add_argument("--steps", type=int, default=30,
+                        help="Number of days to forecast")
+    parser.add_argument("--plot", action="store_true",
+                        help="Plot historical and forecast data")
+    args = parser.parse_args()
+
+    prices = download_close_prices(args.start)
+    forecast = forecast_prices(prices, args.steps)
+    print(forecast)
+
+    if args.plot:
+        plt.figure(figsize=(10, 5))
+        prices.plot(label="Historical")
+        forecast.plot(label="Forecast")
+        plt.legend()
+        plt.title("Bitcoin Price Forecast")
+        plt.ylabel("USD")
+        plt.tight_layout()
+        plt.show()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add simple ARIMA-based bitcoin price forecast script
- document requirements and usage in a dedicated README

## Testing
- `python bitcoin/bitcoin_forecast.py --help`
- `python bitcoin/bitcoin_forecast.py --steps 1 | head`

------
https://chatgpt.com/codex/tasks/task_e_683f754f90fc8329b69b7321285a2235